### PR TITLE
[fix] google-anyscale-iam - Update project access from binding to member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.2.1 (Released)
+
+FEATURES:
+
+BUG FIXES:
+- Change project permission from binding to member
+
+BREAKING CHANGES:
+
 ## 0.2.0 (Released)
 
 FEATURES:

--- a/modules/google-anyscale-iam/README.md
+++ b/modules/google-anyscale-iam/README.md
@@ -29,8 +29,8 @@ No modules.
 |------|------|
 | [google_iam_workload_identity_pool.anyscale_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
 | [google_iam_workload_identity_pool_provider.anyscale_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
-| [google_project_iam_binding.anyscale_access_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
 | [google_project_iam_binding.anyscale_cluster_node_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
+| [google_project_iam_member.anyscale_access_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.anyscale_access_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.anyscale_cluster_node_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_binding.anyscale_access_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |

--- a/modules/google-anyscale-iam/main.tf
+++ b/modules/google-anyscale-iam/main.tf
@@ -45,11 +45,11 @@ resource "google_service_account" "anyscale_access_role" {
 }
 
 #tfsec:ignore:google-iam-no-project-level-service-account-impersonation
-resource "google_project_iam_binding" "anyscale_access_role" {
+resource "google_project_iam_member" "anyscale_access_role" {
   for_each = local.anyscale_access_role_enabled ? toset(var.anyscale_access_role_project_permissions) : []
   role     = each.key
   project  = var.anyscale_project_id
-  members  = ["serviceAccount:${google_service_account.anyscale_access_role[0].email}"]
+  member   = "serviceAccount:${google_service_account.anyscale_access_role[0].email}"
 }
 
 #tfsec:ignore:google-iam-no-project-level-service-account-impersonation


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):


## Description
google-anyscale-iam module:
The service account access for the project is now a member instead of a binding. This is to allow for situations where the binding would override access for other accounts.

On branch release-0.2.1
Changes to be committed:
	modified:   CHANGELOG.md
	modified:   modules/google-anyscale-iam/README.md
	modified:   modules/google-anyscale-iam/main.tf

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
