### PR TITLE
[upd] Cloud APIs sub-module - add additional APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ None
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.64.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.70.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/modules/google-anyscale-cloudapis/README.md
+++ b/modules/google-anyscale-cloudapis/README.md
@@ -15,7 +15,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.64.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.70.0 |
 
 ## Modules
 
@@ -32,7 +32,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_anyscale_activate_apis"></a> [anyscale\_activate\_apis](#input\_anyscale\_activate\_apis) | (Optional) The list of apis to activate within the project.<br>Default enables APIs for compute, filestore, and storage. | `list(string)` | <pre>[<br>  "compute.googleapis.com",<br>  "file.googleapis.com",<br>  "storage-component.googleapis.com",<br>  "storage.googleapis.com",<br>  "certificatemanager.googleapis.com"<br>]</pre> | no |
+| <a name="input_anyscale_activate_apis"></a> [anyscale\_activate\_apis](#input\_anyscale\_activate\_apis) | (Optional) The list of apis to activate within the project.<br>Default enables APIs for compute, filestore, and storage. | `list(string)` | <pre>[<br>  "compute.googleapis.com",<br>  "file.googleapis.com",<br>  "storage-component.googleapis.com",<br>  "storage.googleapis.com",<br>  "certificatemanager.googleapis.com",<br>  "cloudresourcemanager.googleapis.com",<br>  "serviceusage.googleapis.com",<br>  "deploymentmanager.googleapis.com"<br>]</pre> | no |
 | <a name="input_anyscale_cloud_id"></a> [anyscale\_cloud\_id](#input\_anyscale\_cloud\_id) | (Required) Anyscale Cloud ID | `string` | `null` | no |
 | <a name="input_anyscale_project_id"></a> [anyscale\_project\_id](#input\_anyscale\_project\_id) | (Optional) The ID of the project to create the resource in. If not provided, the provider project is used. Default is `null`. | `string` | `null` | no |
 | <a name="input_disable_dependent_services"></a> [disable\_dependent\_services](#input\_disable\_dependent\_services) | (Optional) Determines if services that are enabled and which depend on this service should also be disabled when this service is destroyed.<br>More information in the [terraform documentation](https://www.terraform.io/docs/providers/google/r/google_project_service.html#disable_dependent_services). | `bool` | `true` | no |

--- a/modules/google-anyscale-cloudapis/variables.tf
+++ b/modules/google-anyscale-cloudapis/variables.tf
@@ -55,6 +55,9 @@ variable "anyscale_activate_apis" {
     "storage-component.googleapis.com",
     "storage.googleapis.com",
     "certificatemanager.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "serviceusage.googleapis.com",
+    "deploymentmanager.googleapis.com"
   ]
 }
 

--- a/modules/google-anyscale-cloudstorage/README.md
+++ b/modules/google-anyscale-cloudstorage/README.md
@@ -20,7 +20,7 @@ See the examples folder for how to use.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.64.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.70.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/modules/google-anyscale-filestore/README.md
+++ b/modules/google-anyscale-filestore/README.md
@@ -16,7 +16,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.64.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.70.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/modules/google-anyscale-iam/README.md
+++ b/modules/google-anyscale-iam/README.md
@@ -16,7 +16,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.64.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.70.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/modules/google-anyscale-project/README.md
+++ b/modules/google-anyscale-project/README.md
@@ -17,7 +17,7 @@ Creates a new Google Cloud Project for Anyscale Resources
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.64.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.70.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules

--- a/modules/google-anyscale-vpc-firewall/README.md
+++ b/modules/google-anyscale-vpc-firewall/README.md
@@ -18,7 +18,7 @@ This sub-module builds Google VPC Firewalls that will work with Anyscale.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.64.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.70.0 |
 
 ## Modules
 

--- a/modules/google-anyscale-vpc/README.md
+++ b/modules/google-anyscale-vpc/README.md
@@ -23,7 +23,7 @@ This includes:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.64.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.70.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
 


### PR DESCRIPTION
In reviewing the APIs that are enabled via the terraform, the product team suggested adding the following APIs to the list of enabled APIs:
- cloudresourcemanager.googleapis.com
- serviceusage.googleapis.com
- deploymentmanager.googleapis.com

This matches the APIs that are enabled via `cloud setup` - while not required for Terraform and Anyscale to work, this would cause errors with `cloud verify` if the APIs are not enabled.

Additional updates to readme's and validated with latest Terraform/Google providers.

On branch release-0.5.0
Changes to be committed:
	modified:   README.md
	modified:   modules/google-anyscale-cloudapis/README.md
	modified:   modules/google-anyscale-cloudapis/variables.tf
	modified:   modules/google-anyscale-cloudstorage/README.md
	modified:   modules/google-anyscale-filestore/README.md
	modified:   modules/google-anyscale-iam/README.md
	modified:   modules/google-anyscale-project/README.md
	modified:   modules/google-anyscale-vpc-firewall/README.md
	modified:   modules/google-anyscale-vpc/README.md

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
