### PR TITLE
[fix] google-anyscale-iam - fix descriptions when cloud_id provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.8.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- Fix to the `google-anyscale-iam` submodule when `anyscale_cloud_id` is provided
+  - When `anyscale_cloud_id` is provided, the IAM submodule should update descriptions of the roles/resources created, however the way it was working was looking for a variable that was always null and thus causing a terraform error. This has been replaced with a try to see if the additional variable is populated.
+
+BREAKING CHANGES:
+
+OTHER:
+
+
 ## 0.8.0 (Released)
 FEATURES:
 - New integration for Anyscale Service Head Node fault tolerance.

--- a/modules/google-anyscale-iam/main.tf
+++ b/modules/google-anyscale-iam/main.tf
@@ -4,7 +4,7 @@ locals {
   anyscale_aws_account_id      = var.workload_anyscale_aws_account_id != null ? var.workload_anyscale_aws_account_id : var.anyscale_access_aws_account_id
   anyscale_access_role_enabled = var.module_enabled && var.create_anyscale_access_role ? true : false
 
-  anyscale_access_role_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale access role for cloud ${var.anyscale_cloud_id} in region ${var.google_region}" : null
+  anyscale_access_role_desc_cloud = try("Anyscale access role for cloud ${var.anyscale_cloud_id} in region ${var.google_region}", "Anyscale access role for cloud ${var.anyscale_cloud_id}", null)
   anyscale_access_role_desc = coalesce(
     var.anyscale_access_role_description,
     local.anyscale_access_role_desc_cloud,
@@ -110,7 +110,7 @@ resource "google_service_account_iam_binding" "anyscale_workload_identity_user" 
 locals {
   cluster_node_role_enabled = var.module_enabled && var.create_anyscale_cluster_node_role ? true : false
 
-  anyscale_cluster_node_role_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale cluster node role for cloud ${var.anyscale_cloud_id} in region ${var.google_region}" : null
+  anyscale_cluster_node_role_desc_cloud = try("Anyscale cluster node role for cloud ${var.anyscale_cloud_id} in region ${var.google_region}", "Anyscale cluster node role for cloud ${var.anyscale_cloud_id}", null)
   anyscale_cluster_node_role_desc = coalesce(
     var.anyscale_cluster_node_role_description,
     local.anyscale_cluster_node_role_desc_cloud,


### PR DESCRIPTION
When the `anyscale_cloud_id` variable is provided, the description was looking for a variable that isn't sent to the module. This unblocks this situation - however a more complete will follow and fix to add the missing variable to the module.

On branch brent/iambugfix
Changes to be committed:
	modified:   CHANGELOG.md
	modified:   modules/google-anyscale-iam/main.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):


## Does this introduce a breaking change?
- [ ] Yes
- [x] No

