### PR TITLE
fix: IAM Role for Anyscale - logging support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.12.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- IAM Role fix to support new Anyscale Logging feature.
+
+BREAKING CHANGES:
+
+OTHER:
+
 ## 0.12.0 (Released)
 FEATURES:
 - Update to GCP Terraform Provider v5

--- a/modules/google-anyscale-iam/roles.tf
+++ b/modules/google-anyscale-iam/roles.tf
@@ -151,6 +151,7 @@ resource "google_project_iam_custom_role" "anyscale_access_role" {
     "compute.urlMaps.use",
     "compute.zoneOperations.get",
     "compute.zones.list",
-    "storage.buckets.get"
+    "storage.buckets.get",
+    "storage.objects.get"
   ]
 }


### PR DESCRIPTION
The new logging functionality from Anyscale requires storage.objects.get for the cross account role.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):



## Does this introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

<details>
On branch brent/upd-iam-roles
Changes to be committed:
* modified:   CHANGELOG.md
* modified:   modules/google-anyscale-iam/roles.tf
</details>
