### PR TITLE
fix: google-anyscale-iam: IAM SA Desc when passing in a CloudID

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 default_stages: [pre-commit]
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.96.1
+    rev: v1.96.3
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -22,7 +22,7 @@ repos:
         args:
           - --args=provider google -v "~> 5.0"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,136 @@
+## 0.16.2 (Released)
+FEATURES:
+
+BUG FIXES:
+- Fix IAM SA Description when passing in a Cloud ID
+  - When passing in an Cloud ID, the IAM SA description was trying to add var.google_region however this variable was always null. This caused the IAM SA to fail to create.
+
+BREAKING CHANGES:
+
+OTHER:
+- Uupdates to pre-commit-config.yaml to update to the latest hook versions.
+
+## 0.16.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- E2E test - Additional sleeps for cloud resource deletion
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.16.0 (Released)
+FEATURES:
+- Update CloudStorage from binding to member for IAM policies.
+
+BUG FIXES:
+- Fix firewall Port Assignments were not correctly getting pulled in.
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.15.3 (Released)
+FEATURES:
+
+BUG FIXES:
+- Fix Firewall Rule Names
+  - The firewall rule names were not properly getting pulled from the variable when pulling from the predefined_firewall_rules.
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.15.2 (Released)
+FEATURES:
+
+BUG FIXES:
+- Provide additional outputs and roles for K8s deployments
+  - The new Anyscale K8s Operator has additional permission requirements which have been added to this.
+  - Additional changes to support memberoutputs for IAM Service Accounts.
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.15.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- Add additional ports for Anyscale Machine Pools.
+  - Additional ports opened up for AMP in the `google-anyscale-vpc-firewall` module. The initial ports were only for AMP and did not include Ray specific ports.
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.15.0 (Released)
+FEATURES:
+- add: Optional VPC Firewall ingress rule for Anyscale Machine Pools
+  - Anyscale Machine Pools requires a specific set of ports to be open from the AMP Node into (ingress) the head node running in the cloud. This update includes an optional parameter ingress_from_machine_pool_cidr_ranges which, when provided, will create a new Firewall Rule allowing the appropriate ports for Anyscale Machine Pools.
+
+BUG FIXES:
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.14.4 (Released)
+FEATURES:
+
+BUG FIXES:
+- VPC Firewall ingress for GCP Health Check
+  - The GCP Health Check only needs to be valid for port 8000. The previous fix removed that limitation and opened up all TCP ports.
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.14.3 (Released)
+FEATURES:
+
+BUG FIXES:
+- VPC Firewall when using CIDR Ingress Range
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.14.2 (Released)
+FEATURES:
+
+BUG FIXES:
+- VPC Firewall for Proxy-Only Subnet and Subnet Firewall Rule
+  - When the VPC Proxy Subnet was not in the same CIDR range as the rest of the VPC, the firewall rule was not being correctly configured for the proxy subnet. This change fixes the firewall rule to allow traffic from the proxy subnet to the rest of the VPC and provides a test in the `examples/anyscale-v2-privatenetwork` folder.
+
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.14.1 (Released)
+FEATURES:
+
+BUG FIXES:
+- iam: add storage.objects.list to control plane role
+  - The Workspace dependencies tab requires storage.objects.list permissions.
+
+BREAKING CHANGES:
+
+OTHER:
+
+## 0.14.0 (Released)
+FEATURES:
+- IAM change *_iam_binding to *_iam_members
+  - The current use of *_iam_binding resources is authoritative. It doesn't allow users to add or update members. Changed to use *_iam_members which is non-authoritative. This will be more flexbible and easier to integrate for our users.
+
+BUG FIXES:
+
+BREAKING CHANGES:
+
+OTHER:
+
 ## 0.13.1 (Released)
 FEATURES:
 

--- a/modules/google-anyscale-iam/README.md
+++ b/modules/google-anyscale-iam/README.md
@@ -42,6 +42,7 @@ No modules.
 | [google_service_account_iam_member.anyscale_cluster_node_service_acct](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_service_account_iam_member.anyscale_workload_identity_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [random_id.random_char_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 

--- a/modules/google-anyscale-iam/data.tf
+++ b/modules/google-anyscale-iam/data.tf
@@ -1,0 +1,1 @@
+data "google_client_config" "current" {}

--- a/modules/google-anyscale-iam/gke-sa.tf
+++ b/modules/google-anyscale-iam/gke-sa.tf
@@ -2,8 +2,6 @@
 # GKE Cluster Service Account
 # --------------------------------------------------------------
 locals {
-  google_region = coalesce(var.google_region, data.google_client_config.current.region)
-
   gke_cluster_sa_enabled = var.module_enabled && var.create_gke_cluster_service_acct ? true : false
 
   gke_cluster_sa_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale GKE cluster Service Account ${var.anyscale_cloud_id} in region ${local.google_region}" : null

--- a/modules/google-anyscale-iam/gke-sa.tf
+++ b/modules/google-anyscale-iam/gke-sa.tf
@@ -2,9 +2,11 @@
 # GKE Cluster Service Account
 # --------------------------------------------------------------
 locals {
+  google_region = coalesce(var.google_region, data.google_client_config.current.region)
+
   gke_cluster_sa_enabled = var.module_enabled && var.create_gke_cluster_service_acct ? true : false
 
-  gke_cluster_sa_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale GKE cluster Service Account ${var.anyscale_cloud_id} in region ${var.google_region}" : null
+  gke_cluster_sa_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale GKE cluster Service Account ${var.anyscale_cloud_id} in region ${local.google_region}" : null
   gke_cluster_sa_desc = coalesce(
     var.gke_cluster_service_acct_description,
     local.gke_cluster_sa_desc_cloud,

--- a/modules/google-anyscale-iam/main.tf
+++ b/modules/google-anyscale-iam/main.tf
@@ -1,10 +1,11 @@
 locals {
   random_char_length = var.random_char_length >= 4 && var.random_char_length % 2 == 0 ? var.random_char_length / 2 : 0
 
+  google_region           = coalesce(var.google_region, data.google_client_config.current.region)
   anyscale_aws_account_id = var.workload_anyscale_aws_account_id != null ? var.workload_anyscale_aws_account_id : var.anyscale_access_aws_account_id
 
   anyscale_access_service_acct_enabled    = var.module_enabled && var.create_anyscale_access_service_acct ? true : false
-  anyscale_access_service_acct_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale access service account for cloud ${var.anyscale_cloud_id} in region ${var.google_region}" : null
+  anyscale_access_service_acct_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale access service account for cloud ${var.anyscale_cloud_id} in region ${local.google_region}" : null
   anyscale_access_service_acct_desc = coalesce(
     var.anyscale_access_service_acct_description,
     local.anyscale_access_service_acct_desc_cloud,
@@ -123,7 +124,7 @@ resource "google_service_account_iam_member" "anyscale_workload_identity_user" {
 locals {
   cluster_node_role_enabled = var.module_enabled && var.create_anyscale_cluster_node_service_acct ? true : false
 
-  anyscale_cluster_node_service_acct_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale cluster node role for cloud ${var.anyscale_cloud_id} in region ${var.google_region}" : null
+  anyscale_cluster_node_service_acct_desc_cloud = var.anyscale_cloud_id != null ? "Anyscale cluster node role for cloud ${var.anyscale_cloud_id} in region ${local.google_region}" : null
   anyscale_cluster_node_service_acct_desc = coalesce(
     var.anyscale_cluster_node_service_acct_description,
     local.anyscale_cluster_node_service_acct_desc_cloud,


### PR DESCRIPTION
When passing in an Cloud ID, the IAM SA description was trying to add var.google_region however this variable was always null. This caused the IAM SA to fail to create.

Additional updates to pre-commit-config.yaml to update to the latest hook versions.

On branch brent/fix-iam-sa-desc
Changes to be committed:
	modified:   .pre-commit-config.yaml
	modified:   modules/google-anyscale-iam/README.md
	new file:   modules/google-anyscale-iam/data.tf
	modified:   modules/google-anyscale-iam/gke-sa.tf

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [x] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [ ] Other (please describe):

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
