### PR TITLE
fix: re-add trivy to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,9 @@ repos:
       - id: terraform_tflint
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
-      # - id: terraform_trivy
-      #   args:
-      #     - --args=--quiet
+      - id: terraform_trivy # Known issues with trivy v0.62+ due to null values in some parameters
+        args:
+          - --args=--quiet
       - id: terraform_checkov
         args:
           - --args=--quiet


### PR DESCRIPTION
While troubleshooting trivy, it was removed from the pre-commit hooks. This re-adds it with a note of known problems tied to specific versions of Trivy.

On branch brent/re-add-trivy
Changes to be committed:
	modified:   .pre-commit-config.yaml

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] pre-commit has been run
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All tests passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull Request Type

- [ ] Bugfix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation change
- [x] Other (please describe):
pre-commit update
